### PR TITLE
Fix settings view error. (Fix #13)

### DIFF
--- a/LogCat/LogCatPreferences.m
+++ b/LogCat/LogCatPreferences.m
@@ -14,7 +14,13 @@
 
 - (void)awakeFromNib
 {
-  self.tfAdbPath.stringValue = [[NSUserDefaults standardUserDefaults] objectForKey:PREFS_ADB_PATH];
+    NSString *pathValue = nil;
+    if([[NSUserDefaults standardUserDefaults] objectForKey:PREFS_ADB_PATH] == nil) {
+        pathValue = @"";
+    } else {
+        pathValue = [[NSUserDefaults standardUserDefaults] objectForKey:PREFS_ADB_PATH];
+    }
+    self.tfAdbPath.stringValue = pathValue;
 }
 
 - (void)setupToolbar


### PR DESCRIPTION
Hello guys!

I tried to use your app and it crashed when the settings window was being shown. This should fix it.
Therefore, I found another bug on the settings window that prevents another view from being shown. The only thing Xcode reported was `2014-04-09 15:40:21.107 LogCat[13018:303] NSViewAnimation target is not view or window ((null))`, and I couldn't find a way to fix it.
